### PR TITLE
Feature: Add helper classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,12 @@ Automatically binds `Form` or `FormControl` value and errors based on the `name`
 - vee-validate's [validation-provider props](https://logaretm.github.io/vee-validate/api/validation-provider.html#props)
 
 ### Slots
-#### **label**
-- no props
-#### **icon**
-- no props
-#### **input**
-Props:
+**label**, **icon**, **input**, **error**
+
+All slots receive following props:
 - `value: [String, Number]` - field value, bound through the name prop
 - `errors: String[]` - field errors
 - `on: { [event]: listener }` - event listeners map that should be attached to a form element
-#### **error**
-Props:
-- `errors: String[]` - field errors
 
 ## `FormControl`
 

--- a/README.md
+++ b/README.md
@@ -105,3 +105,20 @@ Props:
 - `values: { [name]: value }`
 - `setValue: (name, value) => undefined`
 - vee-validate's [validation-observer scoped slot props](https://logaretm.github.io/vee-validate/api/validation-observer.html#scoped-slot-props)
+
+# Custom styling
+All elements rendered by `vue-reform` components are given prefixed helper classes that can be targeted.
+
+Here's a list per component:
+  - **FormControl**: `reform-form-control`
+  - **Form**: `reform-form`
+  - **FormField**:
+    - root element: `reform-field`
+    - `label` wrapper element: `reform-invalid`, `reform-dirty`, `reform-required`, `reform-changed`, `reform-touched`, `reform-pending`
+    - control wrapper element: `reform-control`
+    
+    These are optional as they're given to the default slots:
+    - label: `reform-label`
+    - default `input` control element: `reform-input`
+    - error message: `reform-error`
+

--- a/example/App.vue
+++ b/example/App.vue
@@ -1,19 +1,30 @@
 <template>
   <vue-reform @submit="handleSubmit" @invalid="handleInvalid">
     <vue-reform-field
-      name="name"
-      label="Name"
+      name="firstName"
+      label="First name"
       rules="required"
-      placeholder="Name" />
+      placeholder="First name" />
+    <vue-reform-field
+      name="lastName"
+      label="Last name"
+      rules="required"
+      placeholder="Last name" />
+    <vue-reform-field
+      name="email"
+      label="Email (optional)"
+      rules="email"
+      placeholder="Email" />
     <button type="submit">Submit</button>
   </vue-reform>
 </template>
 
 <script>
+import { email, required } from 'vee-validate/dist/rules';
 import { extend } from 'vee-validate';
-import { required } from 'vee-validate/dist/rules';
 
 extend('required', required);
+extend('email', email);
 
 export default {
   methods: {

--- a/example/App.vue
+++ b/example/App.vue
@@ -33,3 +33,19 @@ export default {
   }
 };
 </script>
+
+<style lang="css">
+* {
+  box-sizing: border-box;
+}
+
+.reform-field {
+  max-width: 9.375rem;
+  margin-bottom: 0.25rem;
+}
+
+.reform-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.8125rem;
+}
+</style>

--- a/src/Form.vue
+++ b/src/Form.vue
@@ -1,6 +1,6 @@
 <template>
   <form-control v-slot="props" v-on="$listeners">
-    <form @submit.prevent="props.submit">
+    <form @submit.prevent="props.submit" class="reform-form">
       <slot v-bind="props"></slot>
     </form>
   </form-control>

--- a/src/FormControl.vue
+++ b/src/FormControl.vue
@@ -1,5 +1,9 @@
 <template>
-  <validation-observer ref="observer" v-slot="veeProps" tag="div">
+  <validation-observer
+  ref="observer"
+  v-slot="veeProps"
+  class="reform-form-control"
+  tag="div">
     <slot v-bind="{ ...veeProps, values, setValue, submit }"></slot>
   </validation-observer>
 </template>

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -75,7 +75,7 @@ export default {
   border: 1px solid #e5e5e5;
 }
 
-.reform-invalid.reform-dirty .reform-control {
+.reform-invalid.reform-touched .reform-control {
   box-shadow: 0 0 2px 1px #e74c3c;
 }
 

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -19,7 +19,7 @@
       <slot name="label" v-bind="{ value, errors, ...veeProps }">
         <div v-if="label" class="reform-label">{{ label }}</div>
       </slot>
-      <div class="reform-input">
+      <div class="reform-control">
         <slot name="icon" v-bind="{ value, errors, ...veeProps }"></slot>
         <slot
           name="input" :on="{ input }" v-bind="{ value, errors, ...veeProps }">
@@ -69,17 +69,17 @@ export default {
   padding: 0 0.25rem;
 }
 
-.reform-input {
+.reform-control {
   background-color: transparent;
   border-radius: 3px;
   border: 1px solid #e5e5e5;
 }
 
-.reform-invalid.reform-dirty .reform-input {
-  border-color: #e74c3c;
+.reform-invalid.reform-dirty .reform-control {
+  box-shadow: 0 0 2px 1px #e74c3c;
 }
 
-.reform-input input {
+.reform-control .reform-input {
   width: 100%;
   padding: 0.125rem 0.25rem;
   border: none;

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -65,18 +65,23 @@ export default {
 </script>
 
 <style lang="css">
+.reform-label {
+  padding: 0 0.25rem;
+}
+
 .reform-input {
   background-color: transparent;
   border-radius: 3px;
   border: 1px solid #e5e5e5;
 }
 
-.reform-invalid .reform-input {
-  border: 1px solid red;
+.reform-invalid.reform-dirty .reform-input {
+  border-color: #e74c3c;
 }
 
 .reform-input input {
   width: 100%;
+  padding: 0.125rem 0.25rem;
   border: none;
   background-color: inherit;
 
@@ -84,7 +89,8 @@ export default {
 
 .reform-error {
   font-size: 0.75rem;
-  color: red;
+  line-height: 1.4;
+  color: #e74c3c;
 }
 
 .reform-error::after {

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -1,15 +1,21 @@
 <template>
   <validation-provider
-    v-slot="{ errors }"
+    v-slot="{ errors, ...veeProps }"
     ref="validationProvider"
     v-bind="$attrs"
     :vid="name"
     :name="name"
     class="reform-field"
     tag="div">
-    <label>
-      <slot name="label">
-        <span v-if="label">{{ label }}</span>
+    <label
+      :class="{
+        'reform-invalid': veeProps.invalid,
+        'reform-dirty': veeProps.dirty,
+        'reform-required': veeProps.required,
+        'reform-changed': veeProps.changed,
+        'reform-touched': veeProps.touched,
+        'reform-pending': veeProps.pending
+      }">
       </slot>
       <div class="reform-input">
         <slot name="icon"></slot>

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -1,6 +1,6 @@
 <template>
   <validation-provider
-    v-slot="{ errors, ...veeProps }"
+    v-slot="veeProps"
     ref="validationProvider"
     v-bind="$attrs"
     :vid="name"
@@ -16,13 +16,13 @@
         'reform-touched': veeProps.touched,
         'reform-pending': veeProps.pending
       }">
-      <slot name="label" v-bind="{ ...veeProps, value, errors }">
+      <slot name="label" v-bind="{ ...veeProps, value }">
         <div v-if="label" class="reform-label">{{ label }}</div>
       </slot>
       <div class="reform-control">
-        <slot name="icon" v-bind="{ ...veeProps, value, errors }"></slot>
+        <slot name="icon" v-bind="{ ...veeProps, value }"></slot>
         <slot
-          name="input" :on="{ input }" v-bind="{ ...veeProps, value, errors }">
+          name="input" :on="{ input }" v-bind="{ ...veeProps, value }">
           <input
             @input="input($event.target.value)"
             :value="value"
@@ -31,9 +31,9 @@
         </slot>
       </div>
     </label>
-    <slot name="error" v-bind="{ ...veeProps, value, errors }">
+    <slot name="error" v-bind="{ ...veeProps, value }">
       <div class="reform-error">
-        {{ errors[0] }}
+        {{ veeProps.errors[0] }}
       </div>
     </slot>
   </validation-provider>

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -16,18 +16,22 @@
         'reform-touched': veeProps.touched,
         'reform-pending': veeProps.pending
       }">
+      <slot name="label" v-bind="{ value, errors, ...veeProps }">
+        <div v-if="label" class="reform-label">{{ label }}</div>
       </slot>
       <div class="reform-input">
-        <slot name="icon"></slot>
-        <slot name="input" :on="{ input }" v-bind="{ value, errors }">
+        <slot name="icon" v-bind="{ value, errors, ...veeProps }"></slot>
+        <slot
+          name="input" :on="{ input }" v-bind="{ value, errors, ...veeProps }">
           <input
             @input="input($event.target.value)"
             :value="value"
-            :placeholder="placeholder">
+            :placeholder="placeholder"
+            class="reform-input">
         </slot>
       </div>
     </label>
-    <slot name="error" :errors="errors">
+    <slot name="error" v-bind="{ value, errors, ...veeProps }">
       <div class="reform-error">
         {{ errors[0] }}
       </div>

--- a/src/FormField.vue
+++ b/src/FormField.vue
@@ -16,13 +16,13 @@
         'reform-touched': veeProps.touched,
         'reform-pending': veeProps.pending
       }">
-      <slot name="label" v-bind="{ value, errors, ...veeProps }">
+      <slot name="label" v-bind="{ ...veeProps, value, errors }">
         <div v-if="label" class="reform-label">{{ label }}</div>
       </slot>
       <div class="reform-control">
-        <slot name="icon" v-bind="{ value, errors, ...veeProps }"></slot>
+        <slot name="icon" v-bind="{ ...veeProps, value, errors }"></slot>
         <slot
-          name="input" :on="{ input }" v-bind="{ value, errors, ...veeProps }">
+          name="input" :on="{ input }" v-bind="{ ...veeProps, value, errors }">
           <input
             @input="input($event.target.value)"
             :value="value"
@@ -31,7 +31,7 @@
         </slot>
       </div>
     </label>
-    <slot name="error" v-bind="{ value, errors, ...veeProps }">
+    <slot name="error" v-bind="{ ...veeProps, value, errors }">
       <div class="reform-error">
         {{ errors[0] }}
       </div>


### PR DESCRIPTION
### This PR:
- [x] adds helper classes for style customizations:
  - **FormControl**: `reform-form-control`
  - **Form**: `reform-form`
  - **FormField**: `reform-field`, `reform-invalid`, `reform-dirty`, `reform-required`, `reform-changed`, `reform-touched`, `reform-pending`, `reform-control`, `reform-label`, `reform-input`, `reform-error`
- [x] passes VeeValidates `ValidationProvider` props to all `FormField` slots
- [x] add minimum styling to example
- [x] update slot and custom styling documentation

### Issues
Closes #8 