### PR TITLE
Feature: Enable initializing form data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ import { FormControl, FormField } from 'vue-reform';
 
 `form` element with bounded `FormControl`'s submit listener.
 
+### Props
+- `initialValues: Object` - used to initialize form data
+
 ### Events
 #### **submit**
 Parameters:
@@ -90,6 +93,9 @@ All slots receive following props:
 Top-level form component that keeps track of form's state.
 Form fields are passed using the default slot.
 Emits `submit` event with `formBag` argument.
+
+### Props
+- `initialValues: Object` - used to initialize form data
 
 ### Events
 #### **submit**

--- a/src/Form.vue
+++ b/src/Form.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-control v-slot="props" v-on="$listeners">
+  <form-control v-slot="props" v-on="$listeners" v-bind="$attrs">
     <form @submit.prevent="props.submit" class="reform-form">
       <slot v-bind="props"></slot>
     </form>

--- a/src/FormControl.vue
+++ b/src/FormControl.vue
@@ -13,7 +13,17 @@ import { ValidationObserver } from 'vee-validate';
 
 export default {
   name: 'vue-reform-control',
-  data: () => ({ values: {} }),
+  data() {
+    return {
+      values: { ...this.initialValues }
+    };
+  },
+  props: {
+    initialValues: {
+      type: Object,
+      default: () => ({})
+    }
+  },
   provide() {
     return {
       values: this.values,


### PR DESCRIPTION
### This PR:
- adds `initialValues` prop to `FormControl` that enables passing initial form data